### PR TITLE
Automatically deploy to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -34,11 +34,20 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - uses: actions/setup-python@v5
+      - name: install pandoc
+        run: sudo apt-get install pandoc
+      - name: Docs
+        run: |
+          pip install .
+          cd docs
+          pip install -r docs_requirements.txt
+          make html
       - name: Upload artifact
+        if: ${{ success() }}
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: 'docs/build/html/'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+# Reference https://github.com/actions/starter-workflows/blob/main/pages/static.yml
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
     # You can also specify other tool versions:
     #     # nodejs: "19"
     #         # rust: "1.64"
@@ -27,4 +27,5 @@ sphinx:
 python:
    install:
    - requirements: docs/docs_requirements.txt
-
+   - method: pip
+     path: .

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -3,7 +3,7 @@ torch==1.13
 scikit-image==0.19
 chemparse==0.1
 pillow==9.3
-sphinx==4.5
+sphinx>=5.0
 nbsphinx==0.9
 ipython==8.11
 matplotlib==3.6


### PR DESCRIPTION
Establish a basic GitHub Actions workflow to publish to GitHub Pages
* for new commits pushed to `main`, or
* when manually triggered from the GitHub Actions dashboard.

In addition to the `.github/workflows/page.yml` file, the project Settings need to be updated to enable a GitHub Pages source from GitHub Actions. See https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow